### PR TITLE
Fixed duplicate key error in social links array

### DIFF
--- a/handcrafted-haven/src/components/Footer.tsx
+++ b/handcrafted-haven/src/components/Footer.tsx
@@ -22,7 +22,7 @@ const navlinks: NavLink[] = [
 const socialLinks: SocialLink[] = [
     { label: "Facebook", href: "https://facebook.com", icon: <FaFacebookF size={25}/>},
     { label: "Instagram", href: "https://instagram.com", icon: <FaInstagram size={25}/>},
-    { label: "Facebook", href: "https://twitter.com", icon: <FaTwitter size={25}/>},
+    { label: "Twitter", href: "https://twitter.com", icon: <FaTwitter size={25}/>},
     { label: "Email", href: "https://mailto:info@handcraftedhaven.com", icon: <FaEnvelope size={25}/>},
 ]
 


### PR DESCRIPTION
<img width="1382" height="803" alt="Screenshot 2025-07-26 232502" src="https://github.com/user-attachments/assets/89e1b9c7-81a5-41d1-8ad5-e022844361b1" />


Fixed the duplicate key on the twitter url which was "Facebook" instead of Twitter.